### PR TITLE
Properly fix powerhal nodes

### DIFF
--- a/rootdir/etc/init.power.rc
+++ b/rootdir/etc/init.power.rc
@@ -33,6 +33,19 @@ on init
     write /dev/stune/foreground/schedtune.prefer_idle 1
     write /dev/stune/top-app/schedtune.boost 10
     write /dev/stune/top-app/schedtune.prefer_idle 1
+    
+    # Bring up cpubw governor and set permissions for bw_hwmon nodes
+    write /sys/class/devfreq/soc:qcom,cpubw/governor "bw_hwmon"
+    
+    chown system system /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hyst_trigger_count
+    chown system system /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hyst_length
+    chown system system /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hist_memory
+    chown system system /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/sample_ms
+    
+    chmod 0664 /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hyst_trigger_count
+    chmod 0664 /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hyst_length
+    chmod 0664 /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hist_memory
+    chmod 0664 /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/sample_ms
 
     # Setup permission for Power HAL
     chown system system /dev/stune/top-app/schedtune.boost
@@ -43,11 +56,7 @@ on init
     chown system system /sys/class/kgsl/kgsl-3d0/idle_timer
     chown system system /sys/class/devfreq/soc:qcom,cpubw/min_freq
     chown system system /sys/class/devfreq/soc:qcom,gpubw/min_freq
-    chown system system /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hyst_trigger_count
-    chown system system /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hist_memory
-    chown system system /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/sample_ms
     chown system system /sys/class/devfreq/soc:qcom,memlat-cpu4/min_freq
-    chown system system /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hyst_length
 
     chmod 0664 /dev/stune/top-app/schedtune.boost
     chmod 0664 /sys/class/kgsl/kgsl-3d0/devfreq/min_freq
@@ -56,14 +65,8 @@ on init
     chmod 0664 /sys/class/kgsl/kgsl-3d0/force_clk_on
     chmod 0664 /sys/class/kgsl/kgsl-3d0/idle_timer
     chmod 0664 /sys/class/devfreq/soc:qcom,cpubw/min_freq
-    chmod 0664 /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hyst_trigger_count
-    chmod 0664 /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hist_memory
-    chmod 0664 /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/sample_ms
-    chmod 0664 /sys/class/devfreq/soc:qcom,memlat-cpu4/min_freq
-    chown 0664 /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hist_memory
-    chown 0664 /sys/class/devfreq/soc:qcom,cpubw/bw_hwmon/hyst_length
     chmod 0664 /sys/class/devfreq/soc:qcom,gpubw/min_freq
-    chown 0664 /sys/class/devfreq/soc:qcom,cpubw/min_freq
+    chmod 0664 /sys/class/devfreq/soc:qcom,memlat-cpu4/min_freq
 
 on post-fs-data
     # Set aggressive read ahead for dm-0 and dm-1 during boot up


### PR DESCRIPTION
Nuke some unneeded chown s and fix bw_hwmon nodes permissions by setting cpubw governor first,otherwise permission setting wont work.